### PR TITLE
Np 47451 health check prosjektbanken api

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -143,5 +143,34 @@ Resources:
       RestApiId: !Ref NvaVerifiedFundingSourcesApi
       Stage: !Ref NvaVerifiedFundingSourcesApi.Stage
 
+  ProjectBankHealthCheck:
+    Type: AWS::Route53::HealthCheck
+    Properties:
+      HealthCheckConfig:
+        Port: 443
+        Type: HTTPS
+        ResourcePath: /prosjektbanken/rest/cristin/search?query=healthcheck
+        FullyQualifiedDomainName: prosjektbanken.forskningsradet.no
+        RequestInterval: 30
+        FailureThreshold: 2
+        EnableSNI: true
 
-
+  ProjectBankHealthAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub External-NFR-ProjectBank-API-HealthCheck-${NvaVerifiedFundingSourcesApi} # NvaVerifiedFundingSourcesApi is here just to make the name unique
+      AlarmDescription: Check if external NFR ProjectBank API is healthy
+      Namespace: AWS/Route53
+      MetricName: HealthCheckStatus
+      Dimensions:
+        - Name: HealthCheckId
+          Value: !GetAtt ProjectBankHealthCheck.HealthCheckId
+      Statistic: Minimum
+      Period: 60
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 1
+      ComparisonOperator: LessThanThreshold
+      AlarmActions:
+        - !Ref SlackSnsArn
+      TreatMissingData: notBreaching

--- a/template.yaml
+++ b/template.yaml
@@ -53,6 +53,9 @@ Parameters:
     Type: String
     Description: comma separated list of external clients that are allowed to contact the HTTP APIs, "*" indicates that all origins are allowed
     Default: '*'
+  SlackSnsArn:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: '/NVA/Monitoring/SlackSnsArn'
 
 Resources:
 


### PR DESCRIPTION
Added a health check for NFR Project Bank API and linked it to Slack using Sns.

Used the same setup as already was in nva-cristin-service